### PR TITLE
Move cp of settings folder before site install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,6 +129,11 @@ mv $TEMP_BUILD $DESTINATION
 # set permissions on the sites/default directory
 chmod 755 $DESTINATION/sites/default
 
+# Inculde copies of the settings files that were used to build the site, for reference
+SETTINGS_SITE="$DESTINATION/profiles/$PROJECT/settings"
+cp $SETTINGS_SITE/* $DESTINATION/sites/default/
+echo "Copied all settings files into place."
+
 # run the install profile
 SETTINGS="$DESTINATION/settings/settings_additions.php"
 if [ $DBUSER  ] && [ $DBPASS ] && [ $DB ] ; then
@@ -156,9 +161,5 @@ else
     cat $SETTINGS >> $DESTINATION/sites/default/default.settings.php
   fi
 fi
-
-SETTINGS_SITE="$DESTINATION/profiles/$PROJECT/settings"
-cp $SETTINGS_SITE/* $DESTINATION/sites/default/
-echo "Copied all settings files into place."
 
 echo "Build script complete."


### PR DESCRIPTION
When building a site and choosing to run the install profile, the script presented the following errors at the end:

```
cp: /Users/mikemccaffrey/Sites/pcip/sites/default/config.sh: Permission denied
cp: /Users/mikemccaffrey/Sites/pcip/sites/default/settings_additions.php: Permission denied
cp: /Users/mikemccaffrey/Sites/pcip/sites/default/site.settings.php: Permission denied
```

Even though the script sets the permissions of the sites/default directory to 755, if the install profile is run, drupal changes the permission to 644, and the copy cannot be made. Therefore, it seems like we should move the copy commands up above the part of the script where we run the install profile.
